### PR TITLE
Fix inline styles and scripts

### DIFF
--- a/Syntaxes/CSS (for Blade double-quoted).sublime-syntax
+++ b/Syntaxes/CSS (for Blade double-quoted).sublime-syntax
@@ -9,11 +9,20 @@ hidden: true
 extends: CSS (Blade).sublime-syntax
 
 contexts:
+  main:
+    - include: rule-list-body
 
-  prototype:
+  quoted-strings:
     - meta_prepend: true
     - match: (?=")
       pop: 1
 
-  main:
-    - include: rule-list-body
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1

--- a/Syntaxes/CSS (for Blade single-quoted).sublime-syntax
+++ b/Syntaxes/CSS (for Blade single-quoted).sublime-syntax
@@ -9,11 +9,20 @@ hidden: true
 extends: CSS (Blade).sublime-syntax
 
 contexts:
+  main:
+    - include: rule-list-body
 
-  prototype:
+  quoted-strings:
     - meta_prepend: true
     - match: (?=')
       pop: 1
 
-  main:
-    - include: rule-list-body
+  quoted-string:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  quoted-urls:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1

--- a/Syntaxes/JavaScript (for Blade double-quoted).sublime-syntax
+++ b/Syntaxes/JavaScript (for Blade double-quoted).sublime-syntax
@@ -9,7 +9,24 @@ hidden: true
 extends: JavaScript (Blade).sublime-syntax
 
 contexts:
-  prototype:
+  main:
+    - include: expressions
+
+  expressions:
+    # required until PR #4003 (ST4177)
+    - match: (?=\S)
+      push: [ expression-end, expression-begin ]
+
+  field-name:
     - meta_prepend: true
+    - match: (?=")
+      pop: 1
+
+  method-name:
+    - meta_prepend: true
+    - match: (?=")
+      pop: 1
+
+  literal-single-quoted-string:
     - match: (?=")
       pop: 1

--- a/Syntaxes/JavaScript (for Blade single-quoted).sublime-syntax
+++ b/Syntaxes/JavaScript (for Blade single-quoted).sublime-syntax
@@ -9,7 +9,24 @@ hidden: true
 extends: JavaScript (Blade).sublime-syntax
 
 contexts:
-  prototype:
+  main:
+    - include: expressions
+
+  expressions:
+    # required until PR #4003 (ST4177)
+    - match: (?=\S)
+      push: [ expression-end, expression-begin ]
+
+  field-name:
     - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  method-name:
+    - meta_prepend: true
+    - match: (?=')
+      pop: 1
+
+  literal-single-quoted-string:
     - match: (?=')
       pop: 1

--- a/tests/syntax_test_blade.blade.php
+++ b/tests/syntax_test_blade.blade.php
@@ -1286,6 +1286,25 @@
 {{--                                       ^ punctuation.definition.string.end.html --}}
 {{--                                        ^ meta.tag punctuation.definition.tag.end.html --}}
 
+    <div onclick="{ key: {{ $value }} }">
+{{--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag --}}
+{{--     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html --}}
+{{--     ^^^^^^^ entity.other.attribute-name --}}
+{{--            ^ punctuation.separator.key-value.html --}}
+{{--             ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html --}}
+{{--              ^^^^^^^^^^^^^^^^^^^^^ meta.string.html source.js.embedded.html meta.mapping.js --}}
+{{--              ^ punctuation.section.mapping.begin.js --}}
+{{--                ^^^ meta.mapping.key.js --}}
+{{--                   ^ punctuation.separator.key-value.js --}}
+{{--                     ^^^^^^^^^^^^ meta.interpolation.blade --}}
+{{--                     ^^ punctuation.section.interpolation.begin.blade --}}
+{{--                       ^^^^^^^^ source.php.embedded.blade --}}
+{{--                        ^^^^^^ variable.other.php --}}
+{{--                               ^^ punctuation.section.interpolation.end.blade --}}
+{{--                                  ^ punctuation.section.mapping.end.js --}}
+{{--                                   ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html --}}
+{{--                                    ^ punctuation.definition.tag.end.html --}}
+
     <button @click="alert('Hello World!')">Say Hi</button>
 {{--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag --}}
 {{--        ^^^^^^ meta.embedded.blade source.blade meta.directive.blade variable.function.blade --}}


### PR DESCRIPTION
This commit applies fixes from default PHP syntax to...

1. optimize bailout on quotation marks
2. restrict inline scripts to JavaScript expressions

related with https://github.com/sublimehq/Packages/pull/4060

Note: Relevant contexts are copied to enable fixes for all supported ST builds.

Once all those fixes have been released by ST, embedded CSS/JS could look as follows for supporting releases:

```yml
%YAML 1.2
---
# This hidden syntax is included into quoted strings
# to properly handle {{ echo statements with "quoted strings" }}.
scope: source.css.blade.embedded.string.quoted.double
version: 2
hidden: true

extends:
  - CSS (Blade).sublime-syntax
  - Packages/PHP/Embeddings/CSS (for PHP double-quoted).sublime-syntax
```

and

```yml
%YAML 1.2
---
# This hidden syntax is included into quoted strings
# to properly handle {{ echo statements with "quoted strings" }}.
scope: source.js.blade.embedded.string.quoted.double
version: 2
hidden: true

extends:
  - JavaScript (Blade).sublime-syntax
  - Packages/PHP/Embeddings/JavaScript (for PHP double-quoted).sublime-syntax
```


