### PR TITLE
Fix nested quoted strings in script attribute values

### DIFF
--- a/Syntaxes/JavaScript (for Blade double-quoted).sublime-syntax
+++ b/Syntaxes/JavaScript (for Blade double-quoted).sublime-syntax
@@ -10,6 +10,8 @@ extends: JavaScript (Blade).sublime-syntax
 
 contexts:
   main:
+    - match: \;
+      scope: punctuation.terminator.statement.js
     - include: expressions
 
   expressions:
@@ -17,7 +19,7 @@ contexts:
     - match: (?=\S)
       push: [ expression-end, expression-begin ]
 
-  expression-begin:
+  expression-break:
     - meta_prepend: true
     - match: (?=")
       pop: 1
@@ -32,6 +34,6 @@ contexts:
     - match: (?=")
       pop: 1
 
-  literal-single-quoted-string:
+  literal-double-quoted-string:
     - match: (?=")
       pop: 1

--- a/Syntaxes/JavaScript (for Blade single-quoted).sublime-syntax
+++ b/Syntaxes/JavaScript (for Blade single-quoted).sublime-syntax
@@ -10,6 +10,8 @@ extends: JavaScript (Blade).sublime-syntax
 
 contexts:
   main:
+    - match: \;
+      scope: punctuation.terminator.statement.js
     - include: expressions
 
   expressions:
@@ -17,7 +19,7 @@ contexts:
     - match: (?=\S)
       push: [ expression-end, expression-begin ]
 
-  expression-begin:
+  expression-break:
     - meta_prepend: true
     - match: (?=')
       pop: 1

--- a/tests/syntax_test_blade.blade.php
+++ b/tests/syntax_test_blade.blade.php
@@ -1330,6 +1330,40 @@
 {{--                                   ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html --}}
 {{--                                    ^ punctuation.definition.tag.end.html --}}
 
+    <button onclick="run('event-{{ $events["name"] }}');$alert ='me'">
+{{--        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html --}}
+{{--                ^ meta.string.html string.quoted.double.html punctuation.definition.string.begin.html - source.js --}}
+{{--                 ^^^ meta.string.html source.js.embedded.html meta.function-call variable.function --}}
+{{--                    ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js punctuation.section.group.begin.js --}}
+{{--                     ^^^^^^^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js string.quoted.single.js - meta.interpolation --}}
+{{--                            ^^^^^^^^^^^^^^^^^^^^^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js meta.interpolation.blade --}}
+{{--                                                 ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js string.quoted.single.js punctuation.definition.string.end.js - meta.interpolation --}}
+{{--                                                  ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js punctuation.section.group.end.js --}}
+{{--                                                   ^^^^^^^^^^^^^ meta.string.html source.js.embedded.html --}}
+{{--                                                   ^ punctuation.terminator.statement.js --}}
+{{--                                                    ^^^^^^ variable.other.dollar.js --}}
+{{--                                                           ^ keyword.operator.assignment.js --}}
+{{--                                                            ^^^^ meta.string.js string.quoted.single.js --}}
+{{--                                                                ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html - source.js --}}
+{{--                                                                 ^ punctuation.definition.tag.end.html --}}
+
+    <button onclick='run("event-{{ $events['name'] }}");$alert ="me"'>
+{{--        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.event.html --}}
+{{--                ^ meta.string.html string.quoted.single.html punctuation.definition.string.begin.html - source.js --}}
+{{--                 ^^^ meta.string.html source.js.embedded.html meta.function-call variable.function --}}
+{{--                    ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js punctuation.section.group.begin.js --}}
+{{--                     ^^^^^^^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js string.quoted.double.js - meta.interpolation --}}
+{{--                            ^^^^^^^^^^^^^^^^^^^^^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js meta.interpolation.blade --}}
+{{--                                                 ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js meta.string.js string.quoted.double.js punctuation.definition.string.end.js - meta.interpolation --}}
+{{--                                                  ^ meta.string.html source.js.embedded.html meta.function-call meta.group.js punctuation.section.group.end.js --}}
+{{--                                                   ^^^^^^^^^^^^^ meta.string.html source.js.embedded.html --}}
+{{--                                                   ^ punctuation.terminator.statement.js --}}
+{{--                                                    ^^^^^^ variable.other.dollar.js --}}
+{{--                                                           ^ keyword.operator.assignment.js --}}
+{{--                                                            ^^^^ meta.string.js string.quoted.double.js --}}
+{{--                                                                ^ meta.string.html string.quoted.single.html punctuation.definition.string.end.html - source.js --}}
+{{--                                                                 ^ punctuation.definition.tag.end.html --}}
+
     <button @click="alert('Hello World!')">Say Hi</button>
 {{--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag --}}
 {{--        ^^^^^^ meta.embedded.blade source.blade meta.directive.blade variable.function.blade --}}


### PR DESCRIPTION
This commit...

1. fixes a context name `literal-double-quoted-string` to make sure nested single quoted strings are properly scoped in double-quoted tag attribute values

2. tweaks script termination and chaining of multiple expressions separated by semi-colon.